### PR TITLE
Add support for Folia

### DIFF
--- a/src/main/kotlin/me/ilynxcat/charter/managers/FlightSafetyManager.kt
+++ b/src/main/kotlin/me/ilynxcat/charter/managers/FlightSafetyManager.kt
@@ -29,10 +29,10 @@ internal class FlightSafetyManager(private val plugin: CharterPlugin) {
 		val playSounds = plugin.config.flightSafeLandSoundsEnabled
 		var ticksFalling: Int = 0
 
-		plugin.server.scheduler.runTaskTimer(plugin, { task ->
+		player.scheduler.runAtFixedRate(plugin, { task ->
 			if (!inProgressSafeLandings.contains(player.uniqueId)) {
 				task.cancel()
-				return@runTaskTimer
+				return@runAtFixedRate
 			}
 
 			// TODO: make max safe fall seconds configurable
@@ -50,10 +50,10 @@ internal class FlightSafetyManager(private val plugin: CharterPlugin) {
 					player.playSound(hasLandedPingLow)
 					// wait 0.15sec
 					// then high chime
-					plugin.server.scheduler.runTaskLater(plugin, { _ -> player.playSound(hasLandedPingHigh) }, 3)
+					player.scheduler.runDelayed(plugin, { _ -> player.playSound(hasLandedPingHigh) }, null, 3)
 				}
 				task.cancel()
-				return@runTaskTimer
+				return@runAtFixedRate
 			}
 
 			// every second play a tick
@@ -63,7 +63,7 @@ internal class FlightSafetyManager(private val plugin: CharterPlugin) {
 			}
 
 			ticksFalling++
-		}, 0, 1)
+		}, null, 1, 1)
 		return
 	}
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: '${version ?: '0.1-SNAPSHOT'}'
 main: me.ilynxcat.charter.CharterPlugin
 api-version: '1.21'
 authors: [ iLynxcat <i@ilynxcat.me> ]
+folia-supported: true
 libraries:
   - org.jetbrains.kotlin:kotlin-stdlib:2.1.10
 default-permission: op


### PR DESCRIPTION
Since there’s not much functionality yet, this is a pretty easy commit — just updates the FlightSafetyManager to use Folia’s EntityScheduler instead of the server scheduler!

Also adds `folia-supported: true` to plugin.yml so it can run on Folia servers